### PR TITLE
fix(KcAccountUiLoader.tsx): authUrl can be a string

### DIFF
--- a/src/KcAccountUiLoader.tsx
+++ b/src/KcAccountUiLoader.tsx
@@ -177,6 +177,11 @@ function init(
     }
 
     const { authUrl } = kcContext;
+    
+    if (typeof authUrl === "string") {
+      return authUrl;
+    }
+    
     return `${authUrl.scheme}:${authUrl.rawSchemeSpecificPart.replace(/\$/, "")}`;
   })();
 


### PR DESCRIPTION
there are cases in which `authUrl` can be a string. In these cases the `serverBaseUrl` currently throws because `authUrl.rawSchemeSpecificPart` is `undefined` and therefore `authUrl.rawSchemeSpecificPart.replace` is an invalid access.